### PR TITLE
 Remove 'ikos' from dependencies (space-ros/docker/space-ros#88)

### DIFF
--- a/ament_ikos/package.xml
+++ b/ament_ikos/package.xml
@@ -7,8 +7,6 @@
   <maintainer email="steven@openrobotics.org">Steven! Ragnarök</maintainer>
   <license>Apache-2.0</license>
 
-  <depend>ikos</depend>
-
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>


### PR DESCRIPTION
ikos package does not exist in rosdep index and by keeping it here we need to exclude it with `rosdep --skip-keys` in spaceros build. After this commit, skip-keys on ikos won't be required. Check https://github.com/space-ros/docker/issues/88 for more details.

Ikos will be added back as part of https://github.com/space-ros/docker/issues/99.