### PR TITLE
Fix ament_ikos timeout for large packages (space-ros/docker#138).

### DIFF
--- a/ament_cmake_ikos/cmake/ament_ikos.cmake
+++ b/ament_cmake_ikos/cmake/ament_ikos.cmake
@@ -19,6 +19,7 @@ function(ament_ikos)
   ament_add_test(
     "${ARG_TESTNAME}"
     COMMAND ${cmd}
+    TIMEOUT 1800
     OUTPUT_FILE "${CMAKE_BINARY_DIR}/ament_ikos/${ARG_TESTNAME}.txt"
     RESULT_FILE "${junit_file}"
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"


### PR DESCRIPTION
This PR increases timeout for ikos linter in `ament_cmake_ikos` package, fixing problem C described in https://github.com/space-ros/docker/issues/138.

Of course, I can create a separate issue for this in ament ikos repo if needed.